### PR TITLE
Use IntelliJ's native "open in browser" function

### DIFF
--- a/src/floobits/FloobitsApplication.java
+++ b/src/floobits/FloobitsApplication.java
@@ -18,6 +18,7 @@ import floobits.common.*;
 import floobits.dialogs.CreateAccount;
 import floobits.impl.ContextImpl;
 import floobits.utilities.Flog;
+import floobits.utilities.IntelliBrowserOpener;
 import floobits.utilities.SelectFolder;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +35,7 @@ public class FloobitsApplication implements ApplicationComponent {
     }
 
     public void initComponent() {
+        BrowserOpener.replaceSingleton(new IntelliBrowserOpener());
         ApplicationInfo instance = ApplicationInfo.getInstance();
         IdeaPluginDescriptor plugin = PluginManager.getPlugin(PluginId.getId("com.floobits.unique.plugin.id"));
         createAccount = Bootstrap.bootstrap(instance.getVersionName(), instance.getMajorVersion(), instance.getMinorVersion(), plugin != null ? plugin.getVersion() : "???");

--- a/src/floobits/actions/CompleteSignup.java
+++ b/src/floobits/actions/CompleteSignup.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import floobits.FloobitsPlugin;
+import floobits.common.BrowserOpener;
 import floobits.common.interfaces.IContext;
 import floobits.utilities.Flog;
 import floobits.utilities.IntelliUtils;
@@ -23,7 +24,7 @@ public class CompleteSignup extends AnAction {
         IContext context = plugin.context;
         try {
             URI uri = new URI(url);
-            IntelliUtils.openInBrowser(uri, "Click here to complete sign up.", context);
+            BrowserOpener.getInstance().openInBrowser(uri, "Click here to complete sign up.", context);
         } catch (URISyntaxException error) {
             Flog.error(error);
         }

--- a/src/floobits/actions/CompleteSignup.java
+++ b/src/floobits/actions/CompleteSignup.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import floobits.FloobitsPlugin;
-import floobits.common.Utils;
 import floobits.common.interfaces.IContext;
 import floobits.utilities.Flog;
 import floobits.utilities.IntelliUtils;
@@ -24,7 +23,7 @@ public class CompleteSignup extends AnAction {
         IContext context = plugin.context;
         try {
             URI uri = new URI(url);
-            Utils.openInBrowser(uri, "Click here to complete sign up.", context);
+            IntelliUtils.openInBrowser(uri, "Click here to complete sign up.", context);
         } catch (URISyntaxException error) {
             Flog.error(error);
         }

--- a/src/floobits/actions/GoToHelp.java
+++ b/src/floobits/actions/GoToHelp.java
@@ -4,18 +4,16 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import floobits.FloobitsPlugin;
-import floobits.common.Utils;
+import floobits.common.BrowserOpener;
 import floobits.utilities.Flog;
-import floobits.utilities.IntelliUtils;
 
-import java.awt.*;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
 public class GoToHelp extends AnAction {
     public void actionPerformed(AnActionEvent e) {
-        if(!Desktop.isDesktopSupported()) {
+        BrowserOpener browserOpener = BrowserOpener.getInstance();
+        if(!browserOpener.isBrowserSupported()) {
             Flog.error("Browser not supported on this platform, couldn't open help.");
             return;
         }
@@ -28,6 +26,6 @@ public class GoToHelp extends AnAction {
         }
         Project project = e.getProject();
         FloobitsPlugin plugin = FloobitsPlugin.getInstance(project);
-        IntelliUtils.openInBrowser(uri, "Click here to go to our IntelliJ IDEA help.", plugin.context);
+        browserOpener.openInBrowser(uri, "Click here to go to our IntelliJ IDEA help.", plugin.context);
     }
 }

--- a/src/floobits/actions/GoToHelp.java
+++ b/src/floobits/actions/GoToHelp.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project;
 import floobits.FloobitsPlugin;
 import floobits.common.Utils;
 import floobits.utilities.Flog;
+import floobits.utilities.IntelliUtils;
 
 import java.awt.*;
 import java.io.IOException;
@@ -27,6 +28,6 @@ public class GoToHelp extends AnAction {
         }
         Project project = e.getProject();
         FloobitsPlugin plugin = FloobitsPlugin.getInstance(project);
-        Utils.openInBrowser(uri, "Click here to go to our IntelliJ IDEA help.", plugin.context);
+        IntelliUtils.openInBrowser(uri, "Click here to go to our IntelliJ IDEA help.", plugin.context);
     }
 }

--- a/src/floobits/actions/OpenSettingsInBrowser.java
+++ b/src/floobits/actions/OpenSettingsInBrowser.java
@@ -8,6 +8,7 @@ import floobits.common.FlooUrl;
 import floobits.common.Utils;
 import floobits.impl.ContextImpl;
 import floobits.utilities.Flog;
+import floobits.utilities.IntelliUtils;
 
 import java.awt.*;
 import java.io.IOException;
@@ -24,7 +25,7 @@ public class OpenSettingsInBrowser extends CanFloobits {
             return;
         }
         try {
-            Utils.openInBrowser(new URI(String.format("%s/settings", flooUrl.toString())), "Click here to open your settings", context);
+            IntelliUtils.openInBrowser(new URI(String.format("%s/settings", flooUrl.toString())), "Click here to open your settings", context);
         } catch (URISyntaxException e) {
             Flog.info("Couldn't open settings in browser", e);
         }

--- a/src/floobits/actions/OpenSettingsInBrowser.java
+++ b/src/floobits/actions/OpenSettingsInBrowser.java
@@ -3,15 +3,12 @@ package floobits.actions;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import floobits.FloobitsPlugin;
+import floobits.common.BrowserOpener;
 import floobits.common.DotFloo;
 import floobits.common.FlooUrl;
-import floobits.common.Utils;
 import floobits.impl.ContextImpl;
 import floobits.utilities.Flog;
-import floobits.utilities.IntelliUtils;
 
-import java.awt.*;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -25,7 +22,7 @@ public class OpenSettingsInBrowser extends CanFloobits {
             return;
         }
         try {
-            IntelliUtils.openInBrowser(new URI(String.format("%s/settings", flooUrl.toString())), "Click here to open your settings", context);
+            BrowserOpener.getInstance().openInBrowser(new URI(String.format("%s/settings", flooUrl.toString())), "Click here to open your settings", context);
         } catch (URISyntaxException e) {
             Flog.info("Couldn't open settings in browser", e);
         }

--- a/src/floobits/actions/OpenWorkspaceInBrowser.java
+++ b/src/floobits/actions/OpenWorkspaceInBrowser.java
@@ -16,6 +16,7 @@ import floobits.common.FlooUrl;
 import floobits.common.Utils;
 import floobits.impl.ContextImpl;
 import floobits.utilities.Flog;
+import floobits.utilities.IntelliUtils;
 
 import java.awt.*;
 import java.net.URI;
@@ -54,7 +55,7 @@ public class OpenWorkspaceInBrowser extends CanFloobits {
             Flog.info("Couldn't open settings in browser", e);
             return;
         }
-        Utils.openInBrowser(uri, "Click here to go your project's settings.", context);
+        IntelliUtils.openInBrowser(uri, "Click here to go your project's settings.", context);
     }
 
 }

--- a/src/floobits/actions/OpenWorkspaceInBrowser.java
+++ b/src/floobits/actions/OpenWorkspaceInBrowser.java
@@ -11,12 +11,12 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import floobits.FloobitsPlugin;
+import floobits.common.BrowserOpener;
 import floobits.common.DotFloo;
 import floobits.common.FlooUrl;
 import floobits.common.Utils;
 import floobits.impl.ContextImpl;
 import floobits.utilities.Flog;
-import floobits.utilities.IntelliUtils;
 
 import java.awt.*;
 import java.net.URI;
@@ -55,7 +55,7 @@ public class OpenWorkspaceInBrowser extends CanFloobits {
             Flog.info("Couldn't open settings in browser", e);
             return;
         }
-        IntelliUtils.openInBrowser(uri, "Click here to go your project's settings.", context);
+        BrowserOpener.getInstance().openInBrowser(uri, "Click here to go your project's settings.", context);
     }
 
 }

--- a/src/floobits/common/BrowserOpener.java
+++ b/src/floobits/common/BrowserOpener.java
@@ -1,0 +1,73 @@
+package floobits.common;
+
+import floobits.common.interfaces.IContext;
+import floobits.utilities.Flog;
+
+import java.awt.*;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Singleton class providing open-in-browser function.
+ * Defaults to using java.awt.Desktop.browse().
+ * Singleton can be replaced to provide plugin-specific browse() features
+ */
+public class BrowserOpener {
+
+    private static BrowserOpener singleton;
+
+    /**
+     * @return the "singleton" BrowserOpener instance
+     */
+    public static BrowserOpener getInstance() {
+        if (null == singleton) {
+            singleton = new BrowserOpener();
+        }
+        return singleton;
+    }
+
+    /**
+     * Replace the instance of BrowserOpener.  Can be used to provide
+     * plugin-specific functionality that can still be called from common code.
+     * @param newInstance the new BrowserOpener instance to use
+     */
+    public static void replaceSingleton(BrowserOpener newInstance) {
+        singleton = newInstance;
+    }
+
+    /**
+     * @return Whether we are likely to be able to open a browser window
+     *         on this system.
+     */
+    public boolean isBrowserSupported() {
+        return Desktop.isDesktopSupported();
+    }
+
+    /**
+     * Open the system's default browser to the specified URI
+     * @param uri - The link to open
+     * @param defaultLinkText - Link text for hyperlink dropped into console if opening browser fails
+     * @param context - Application context so that we can write to console if needed
+     * @return boolean true if the browser was successfully opened.
+     */
+    public boolean openInBrowser(URI uri, String defaultLinkText, IContext context) {
+        boolean shown = false;
+        String linkText = "Please click here to continue.";
+        if (defaultLinkText != null) {
+            linkText = defaultLinkText;
+        }
+        if(Desktop.isDesktopSupported()) {
+            try {
+                Desktop.getDesktop().browse(uri);
+                shown = true;
+            } catch (IOException error) {
+                Flog.error(error);
+            }
+        }
+        if (!shown && context != null) {
+            context.errorMessage("Could not open your system's browser.");
+            context.statusMessage(Utils.getLinkHTML(linkText, uri.toString()));
+        }
+        return shown;
+    }
+}

--- a/src/floobits/common/Utils.java
+++ b/src/floobits/common/Utils.java
@@ -1,6 +1,5 @@
 package floobits.common;
 
-import floobits.FloobitsPlugin;
 import floobits.common.interfaces.IContext;
 import floobits.common.interfaces.IFile;
 import floobits.utilities.Flog;
@@ -8,11 +7,8 @@ import org.apache.commons.io.FilenameUtils;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
-import javax.swing.event.HyperlinkEvent;
-import java.awt.*;
 import java.io.*;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -280,24 +276,7 @@ public class Utils {
     }
 
     static public boolean openInBrowser(URI uri, String defaultLinkText, IContext context) {
-        boolean shown = false;
-        String linkText = "Please click here to continue.";
-        if (defaultLinkText != null) {
-            linkText = defaultLinkText;
-        }
-        if(Desktop.isDesktopSupported()) {
-            try {
-                Desktop.getDesktop().browse(uri);
-                shown = true;
-            } catch (IOException error) {
-                Flog.error(error);
-            }
-        }
-        if (!shown && context != null) {
-            context.errorMessage("Could not open your system's browser.");
-            context.statusMessage(getLinkHTML(linkText, uri.toString()));
-        }
-        return shown;
+        return BrowserOpener.getInstance().openInBrowser(uri, defaultLinkText, context);
     }
 
 }

--- a/src/floobits/common/protocol/handlers/LinkEditorHandler.java
+++ b/src/floobits/common/protocol/handlers/LinkEditorHandler.java
@@ -8,8 +8,6 @@ import floobits.common.protocol.Connection;
 import floobits.common.protocol.json.send.FlooRequestCredentials;
 import floobits.utilities.Flog;
 
-import java.awt.*;
-import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -81,7 +79,8 @@ public class LinkEditorHandler extends BaseHandler {
     }
 
     protected void openBrowser() {
-        if(!Desktop.isDesktopSupported()) {
+        BrowserOpener browserOpener = BrowserOpener.getInstance();
+        if(!browserOpener.isBrowserSupported()) {
             context.errorMessage("Floobits can't use a browser on this system.");
             context.shutdown();
             return;
@@ -93,7 +92,7 @@ public class LinkEditorHandler extends BaseHandler {
             Flog.error(error);
             return;
         }
-        if (!Utils.openInBrowser(uri, "Click here to sign in to Floobits.", context)) {
+        if (!browserOpener.openInBrowser(uri, "Click here to sign in to Floobits.", context)) {
             context.shutdown();
             context.errorMessage("Could not sign you in. Please check our .floorc.json documentation on our help pages.");
         }

--- a/src/floobits/utilities/IntelliBrowserOpener.java
+++ b/src/floobits/utilities/IntelliBrowserOpener.java
@@ -1,0 +1,42 @@
+package floobits.utilities;
+
+import com.intellij.ide.BrowserUtil;
+import floobits.common.BrowserOpener;
+import floobits.common.interfaces.IContext;
+
+import java.net.URI;
+
+/**
+ * Override openInBrowser behavior to try IntelliJ's built-in function first.
+ * Must be instantiated and used to replace the default BrowserOpener singleton.
+ */
+public class IntelliBrowserOpener extends BrowserOpener {
+
+    /**
+     * @return Whether we are likely to be able to open a browser window
+     *         on this system (IntelliJ assumes this will always work)
+     */
+    public boolean isBrowserSupported() {
+        return true;
+    }
+
+    /**
+     * Wrap the common Utils.openInBrowser function so that we first attempt to use
+     * IntelliJ's native open-in-browser feature, which works more reliably across platforms.
+     * @param uri - The link to open
+     * @param defaultLinkText - Link text for hyperlink dropped into console if opening browser fails
+     * @param context - Application context so that we can write to console if needed
+     * @return boolean true if the browser was successfully opened.
+     */
+    public boolean openInBrowser(URI uri, String defaultLinkText, IContext context) {
+        boolean shown;
+        try {
+            BrowserUtil.browse(uri);
+            shown = true;
+        } catch (Exception e) {
+            BrowserOpener defaultOpener = new BrowserOpener();
+            shown = defaultOpener.openInBrowser(uri, defaultLinkText, context);
+        }
+        return shown;
+    }
+}

--- a/src/floobits/utilities/IntelliUtils.java
+++ b/src/floobits/utilities/IntelliUtils.java
@@ -1,5 +1,6 @@
 package floobits.utilities;
 
+import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ContentIterator;
 import com.intellij.openapi.vfs.VFileProperty;
@@ -128,10 +129,30 @@ public class IntelliUtils {
                 return;
             }
             FloobitsPlugin plugin = FloobitsPlugin.getInstance(project);
-            if (!Utils.openInBrowser(uri, "Click to continue.", plugin.context)) {
+            if (!openInBrowser(uri, "Click to continue.", plugin.context)) {
                 plugin.context.errorMessage(
                         String.format("You cannot click on links in IntelliJ apparently, try copy and paste: %s.", uri.toString()));
             }
         }
+    }
+
+    /**
+     * Wrap the common Utils.openInBrowser function so that we first attempt to use
+     * IntelliJ's native open-in-browser feature, which works more reliably across platforms.
+     * @param uri - The link to open
+     * @param defaultLinkText - Link text for hyperlink dropped into console if opening browser fails
+     * @param context - Application context so that we can write to console if needed
+     * @return boolean true if the browser was successfully opened.
+     */
+    static public boolean openInBrowser(URI uri, String defaultLinkText, IContext context) {
+        boolean shown = false;
+        try {
+            BrowserUtil.browse(uri);
+            context.statusMessage(Utils.getLinkHTML(defaultLinkText, uri.toString()));
+            shown = true;
+        } catch (Exception e) {
+            shown = Utils.openInBrowser(uri, defaultLinkText, context);
+        }
+        return shown;
     }
 }

--- a/src/floobits/utilities/IntelliUtils.java
+++ b/src/floobits/utilities/IntelliUtils.java
@@ -1,22 +1,17 @@
 package floobits.utilities;
 
-import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ContentIterator;
 import com.intellij.openapi.vfs.VFileProperty;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import floobits.FloobitsPlugin;
-import floobits.common.Constants;
-import floobits.common.PersistentJson;
-import floobits.common.Settings;
-import floobits.common.Utils;
+import floobits.common.*;
 import floobits.common.interfaces.IContext;
 import floobits.common.interfaces.IFile;
 import floobits.impl.FileImpl;
 
 import javax.swing.event.HyperlinkEvent;
-import java.awt.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -81,7 +76,7 @@ public class IntelliUtils {
             Flog.errorMessage("Error, no account details detected. You will have to sign up manually.", project);
             return null;
         }
-        if(!Desktop.isDesktopSupported()) {
+        if(!BrowserOpener.getInstance().isBrowserSupported()) {
             Flog.errorMessage("Can't use a browser on this system.", project);
             return null;
         }
@@ -129,30 +124,10 @@ public class IntelliUtils {
                 return;
             }
             FloobitsPlugin plugin = FloobitsPlugin.getInstance(project);
-            if (!openInBrowser(uri, "Click to continue.", plugin.context)) {
+            if (!BrowserOpener.getInstance().openInBrowser(uri, "Click to continue.", plugin.context)) {
                 plugin.context.errorMessage(
                         String.format("You cannot click on links in IntelliJ apparently, try copy and paste: %s.", uri.toString()));
             }
         }
-    }
-
-    /**
-     * Wrap the common Utils.openInBrowser function so that we first attempt to use
-     * IntelliJ's native open-in-browser feature, which works more reliably across platforms.
-     * @param uri - The link to open
-     * @param defaultLinkText - Link text for hyperlink dropped into console if opening browser fails
-     * @param context - Application context so that we can write to console if needed
-     * @return boolean true if the browser was successfully opened.
-     */
-    static public boolean openInBrowser(URI uri, String defaultLinkText, IContext context) {
-        boolean shown = false;
-        try {
-            BrowserUtil.browse(uri);
-            context.statusMessage(Utils.getLinkHTML(defaultLinkText, uri.toString()));
-            shown = true;
-        } catch (Exception e) {
-            shown = Utils.openInBrowser(uri, defaultLinkText, context);
-        }
-        return shown;
     }
 }


### PR DESCRIPTION
Fixes [#239: "In Browser" operations not working in Ubuntu.](https://github.com/Floobits/floobits-intellij/issues/239)

Creates a `BrowserOpener` singleton that wraps the standard [`java.awt.Desktop.browse()`](http://docs.oracle.com/javase/6/docs/api/java/awt/Desktop.html#browse(java.net.URI)) functionality, which continues to be used within the "common" subtree (to remain compatible with other IDE plugins).  Note, I've left the now-unused `Utils.openInBrowser()` function in place as a pass-through to `BrowserOpener.getInstance().openInBrowser()` so not to break possible usages by other plugins.

On initialization, the IntelliJ plugin replaces the `BrowserOpener` singleton with its own `IntelliBrowserOpener` which tries to use [`com.intellij.ide.BrowserUtil`](https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/ide/BrowserUtil.java) to open the browser instead (A fallback to the standard `java.awt.Desktop` behavior is provided in case IntelliJ's function throws an exception, but based on their documentation this doesn't seem to ever happen).

I've verified that this fixes all "open in browser" behaviors for me on Ubuntu 15.04, including:

* **Open Workspace in Browser** and **Open Workspace Settings in Browser** from the **Tools > Floobits** menu or from the UI buttons.
* Clicking links in the Floobits console
* The "I already have an account" flow on initial setup, including automatic configuration of the local workspace.

I could use some help verifying these fixes on other platforms (I don't currently have access to any Windows or OSX machines) and I'm not sure whether I need to do something special to push the changes to the "common" subtree - they seem to show up fine in the pull request.

Thanks!