### PR TITLE
Update to valid 2020.1 icons

### DIFF
--- a/src/floobits/windows/FloobitsWindowForm.java
+++ b/src/floobits/windows/FloobitsWindowForm.java
@@ -145,7 +145,7 @@ public class FloobitsWindowForm {
                         e.getPresentation().setEnabled(flooHandler != null);
                     }
                 },
-                new AnAction(clearHighlightsLabel, clearHighlightsLabel, AllIcons.ObjectBrowser.ShowEditorHighlighting) {
+                new AnAction(clearHighlightsLabel, clearHighlightsLabel, AllIcons.Actions.Edit) {
                     @Override
                     public void actionPerformed(AnActionEvent e) {
                         new ClearHighlights().actionPerformed(e);
@@ -213,7 +213,7 @@ public class FloobitsWindowForm {
                         e.getPresentation().setEnabled(flooHandler != null && flooHandler.state.getFollowing());
                     }
                 },
-                new AnAction(openBrowserLabel, openBrowserLabel, AllIcons.Actions.Nextfile) {
+                new AnAction(openBrowserLabel, openBrowserLabel, AllIcons.Actions.Forward) {
                     @Override
                     public void actionPerformed(AnActionEvent e) {
                         new OpenWorkspaceInBrowser().actionPerformed(e);


### PR DESCRIPTION
Addresses issue #278

Version 2020.1 removed the NextFile and ShowEditorHighlighting icons and the recommend icons are AllIcons.Actions.Edit and AllIcons.Actions.Forward

https://github.com/JetBrains/intellij-community/blob/1ef4ef2466913559c46118ac01ce44cc99b45721/platform/util/src/com/intellij/icons/AllIcons.java#L381
https://github.com/JetBrains/intellij-community/blob/1ef4ef2466913559c46118ac01ce44cc99b45721/platform/util/src/com/intellij/icons/AllIcons.java#L2653